### PR TITLE
fix: la couleur dans la status bar n'était pas bonne

### DIFF
--- a/app/src/scenes/onboarding-v2/BeigeWrapperScreen.tsx
+++ b/app/src/scenes/onboarding-v2/BeigeWrapperScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Dimensions } from 'react-native';
+import { Dimensions, StatusBar } from 'react-native';
 import NavigationButtons from '@/components/onboarding/NavigationButtons';
 import CheckInHeader from '@/components/onboarding/CheckInHeader';
 import { TW_COLORS } from '@/utils/constants';
@@ -25,6 +25,15 @@ const VARIANT_COLORS = {
     green: `bg-[#EEF9F1]`,
     blue: `bg-[#E8F7F4]`,
 }
+
+const VARIANT_RAW_COLORS = {
+    beige: '#FDF2E7',
+    red: '#FAEEEF',
+    pink: '#FEF8FB',
+    white: TW_COLORS.WHITE,
+    green: '#EEF9F1',
+    blue: '#E8F7F4',
+};
 
 const VARIANT_BORDER_COLORS = {
     beige: 'bg-[#FDF2E7]',
@@ -74,6 +83,7 @@ export const BeigeWrapperScreen: React.FC<Props> = ({
 
     return (
         <SafeAreaViewWithOptionalHeader className={`flex-1 ${VARIANT_COLORS[variant]}`}>
+            <StatusBar backgroundColor={VARIANT_RAW_COLORS[variant]} />
             <CheckInHeader
                 title=""
                 onPrevious={handlePrevious}


### PR DESCRIPTION
Suggestion pour la suite : 

1. (major) Supprimer le `useStatusBar` qui repose sur un hook maison et le contexte qui sont deux éléments fragilisant. D'autant plus que d'après la doc de react native, il suffit de surcharger d'un nouveau `StatusBar` quand on veut changer quelque chose pour un écran en particulier.
2. (minor) Ne pas utiliser tailwind pour ce cas particulier, parce qu'on transforme une couleur en tailwind pour la retransformer en css et que tailwind n'aime pas toujours les chaines construites depuis l'extérieur. Pour ce cas particulier, la liste des constantes en `bg` n'apporte pas grand chose.