### PR TITLE
fix: pass genericIndicator to IndicatorModal

### DIFF
--- a/app/src/scenes/onboarding-v2/indicators/IndicatorModal.tsx
+++ b/app/src/scenes/onboarding-v2/indicators/IndicatorModal.tsx
@@ -85,6 +85,7 @@ export default function IndicatorModal({
       categories: [category],
       mainCategory: category,
       priority: 0,
+      matomoId: -1, // no matomo id for custom indicators
     };
   };
 

--- a/app/src/scenes/onboarding-v2/indicators/OnboardingChooseIndicatorScreen.tsx
+++ b/app/src/scenes/onboarding-v2/indicators/OnboardingChooseIndicatorScreen.tsx
@@ -496,7 +496,7 @@ const CategoryCard = ({
                   <IndicatorModal
                     userIndicators={[]}
                     category={categoryName}
-                    genericIndicator={BASE_INDICATORS_FOR_CUSTOM_CATEGORIES[categoryName][0]}
+                    genericIndicator={BASE_INDICATORS_FOR_CUSTOM_CATEGORIES[categoryName]?.[0]}
                     addedIndicators={indicators}
                     initialSelectedIndicators={Object.values(selectedIndicators).flat()}
                     onClose={(categoryName: NEW_INDICATORS_CATEGORIES, indicators: PredefineIndicatorV2SchemaType[]) => {

--- a/app/src/scenes/onboarding-v2/indicators/OnboardingChooseIndicatorScreen.tsx
+++ b/app/src/scenes/onboarding-v2/indicators/OnboardingChooseIndicatorScreen.tsx
@@ -496,6 +496,7 @@ const CategoryCard = ({
                   <IndicatorModal
                     userIndicators={[]}
                     category={categoryName}
+                    genericIndicator={BASE_INDICATORS_FOR_CUSTOM_CATEGORIES[categoryName][0]}
                     addedIndicators={indicators}
                     initialSelectedIndicators={Object.values(selectedIndicators).flat()}
                     onClose={(categoryName: NEW_INDICATORS_CATEGORIES, indicators: PredefineIndicatorV2SchemaType[]) => {

--- a/app/src/utils/liste_indicateurs.1.ts
+++ b/app/src/utils/liste_indicateurs.1.ts
@@ -324,7 +324,7 @@ export const INDICATORS: PredefineIndicatorV2SchemaType[] = [
     subcategories: [NEW_INDICATORS_SUBCATEGORIES.BAD_SLEEP_HABITS],
     category: INDICATORS_CATEGORIES.Comportements,
     order: "DESC",
-    type: INDICATOR_TYPE.boolean,
+    type: INDICATOR_TYPE.gauge,
     new: true,
     uuid: "bf9014c2-8e47-4c5f-9a2a-41e48c46496a",
     mainCategory: NEW_INDICATORS_CATEGORIES.SLEEP,


### PR DESCRIPTION
Indicator type is based on genericIndicator pass as params otherwise it defaults to boolean. Pass genericIndicator to IndicatorModal to allow indicator to have the right type.