### PR TITLE
fix: add back today.svg and yesterday.svg import as there are still used

### DIFF
--- a/app/src/components/CircledIcon.tsx
+++ b/app/src/components/CircledIcon.tsx
@@ -8,6 +8,8 @@ import SmileyMiddle from "@assets/svg/smileys/middle";
 import SmileyBad from "@assets/svg/smileys/bad";
 import SmileyVeryBad from "@assets/svg/smileys/veryBad";
 import PlusIcon from "@assets/svg/icon/plus";
+import TodaySvg from "../../assets/svg/today.svg";
+import YesterdaySvg from "../../assets/svg/yesterday.svg";
 
 const styles = StyleSheet.create({
   iconContainer: {
@@ -32,6 +34,8 @@ const mapIconToSvg = (icon) => {
     VeryBadSvg: SmileyVeryBad,
     QuestionMarkSvg,
     Plus: PlusIcon,
+    TodaySvg,
+    YesterdaySvg,
   };
   return iconMap[icon];
 };

--- a/app/src/components/CircledIcon.tsx
+++ b/app/src/components/CircledIcon.tsx
@@ -8,8 +8,8 @@ import SmileyMiddle from "@assets/svg/smileys/middle";
 import SmileyBad from "@assets/svg/smileys/bad";
 import SmileyVeryBad from "@assets/svg/smileys/veryBad";
 import PlusIcon from "@assets/svg/icon/plus";
-import TodaySvg from "../../assets/svg/today.svg";
-import YesterdaySvg from "../../assets/svg/yesterday.svg";
+import TodaySvg from "@assets/svg/today.svg";
+import YesterdaySvg from "@assets/svg/yesterday.svg";
 
 const styles = StyleSheet.create({
   iconContainer: {

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -14,7 +14,6 @@ import HorizontalDots from "@assets/svg/icon/HorizontalDots";
 import MessageHeartCircleIcon from "@assets/svg/icon/MessageHeartCircle";
 import { SquircleButton } from "expo-squircle-view";
 import { TW_COLORS } from "@/utils/constants";
-import logEvents from "@/services/logEvents";
 
 interface HeaderProps {
   title: string;

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -14,6 +14,7 @@ import HorizontalDots from "@assets/svg/icon/HorizontalDots";
 import MessageHeartCircleIcon from "@assets/svg/icon/MessageHeartCircle";
 import { SquircleButton } from "expo-squircle-view";
 import { TW_COLORS } from "@/utils/constants";
+import logEvents from "@/services/logEvents";
 
 interface HeaderProps {
   title: string;

--- a/app/src/types/global.d.ts
+++ b/app/src/types/global.d.ts
@@ -1,2 +1,10 @@
 // global.d.ts
 /// <reference types="nativewind/types" />
+
+// SVG module declarations
+declare module "*.svg" {
+  import React from "react";
+  import { SvgProps } from "react-native-svg";
+  const content: React.FC<SvgProps>;
+  export default content;
+}


### PR DESCRIPTION
Quand on essaye de remplir un formulaire via le bouton flotant l'app crash car on ouvre une page qui utilise today.svg et yeaterday.svg dont les imports on été retirés.