### PR TITLE
chore(matomo): preserve key order when log in dev mode

### DIFF
--- a/app/src/services/matomo.js
+++ b/app/src/services/matomo.js
@@ -87,7 +87,7 @@ class Api {
       if (!this.initDone) {
         throw new Error("matomo not initialized yet");
       }
-      if (__DEV__) return console.log(params);
+      if (__DEV__) return console.log(JSON.stringify(params));
       const url = `${this.baseUrl}?${this.computeParams(params, this.idsite)}`;
       const res = await fetch(encodeURI(url));
       // if (__DEV__) {


### PR DESCRIPTION
Désolé c'est un peu un hack, mais c'est parce qu'en fait console.log "trie" les clés par ordre alphabétique.
TU n'es pas obligé d'accepter, pour le coup c'est juste une proposition !