### PR TITLE
chore: update inactivity reminder only after onboarding

### DIFF
--- a/app/src/scenes/status/index.tsx
+++ b/app/src/scenes/status/index.tsx
@@ -52,11 +52,14 @@ const Status = ({ navigation, startSurvey }) => {
     }, [])
   );
 
-  React.useEffect(async () => {
-    const onboardingIsDone = await localStorage.getOnboardingDone();
-    if (onboardingIsDone) {
-      updateInactivityReminder();
-    }
+  React.useEffect(() => {
+    const initializeReminder = async () => {
+      const onboardingIsDone = await localStorage.getOnboardingDone();
+      if (onboardingIsDone) {
+        updateInactivityReminder();
+      }
+    };
+    initializeReminder();
   }, []);
 
   React.useEffect(() => {

--- a/app/src/scenes/status/index.tsx
+++ b/app/src/scenes/status/index.tsx
@@ -52,10 +52,11 @@ const Status = ({ navigation, startSurvey }) => {
     }, [])
   );
 
-  React.useEffect(() => {
-    updateInactivityReminder();
-    checkOldReminderBefore154(); // can be deleted in few months
-    checkOldReminderBefore193(); // can be deleted in few months
+  React.useEffect(async () => {
+    const onboardingIsDone = await localStorage.getOnboardingDone();
+    if (onboardingIsDone) {
+      updateInactivityReminder();
+    }
   }, []);
 
   React.useEffect(() => {


### PR DESCRIPTION
Cette update semble responsable de la demande de notification sur IOS, et ça ne sert à rien de le faire tant que l'utilisateur n'a pas passé l'onboarding.
je supprime au passage l'update selon le format qui ne sert plus à rien.